### PR TITLE
Add Codex CLI language model settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1762,6 +1762,9 @@
     "google": {
       "api_url": "https://generativelanguage.googleapis.com"
     },
+    "codex_cli": {
+      "binary_path": "codex"
+    },
     "ollama": {
       "api_url": "http://localhost:11434"
     },

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -24,6 +24,11 @@ use crate::provider::{
     x_ai::XAiSettings,
 };
 
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct CodexCliSettings {
+    pub binary_path: String,
+}
+
 /// Initializes the language model settings.
 pub fn init_settings(cx: &mut App) {
     AllLanguageModelSettings::register(cx);
@@ -33,6 +38,7 @@ pub fn init_settings(cx: &mut App) {
 pub struct AllLanguageModelSettings {
     pub anthropic: AnthropicSettings,
     pub bedrock: AmazonBedrockSettings,
+    pub codex_cli: CodexCliSettings,
     pub deepseek: DeepSeekSettings,
     pub google: GoogleSettings,
     pub lmstudio: LmStudioSettings,
@@ -50,6 +56,7 @@ pub struct AllLanguageModelSettings {
 pub struct AllLanguageModelSettingsContent {
     pub anthropic: Option<AnthropicSettingsContent>,
     pub bedrock: Option<AmazonBedrockSettingsContent>,
+    pub codex_cli: Option<CodexCliSettingsContent>,
     pub deepseek: Option<DeepseekSettingsContent>,
     pub google: Option<GoogleSettingsContent>,
     pub lmstudio: Option<LmStudioSettingsContent>,
@@ -77,6 +84,12 @@ pub struct AmazonBedrockSettingsContent {
     region: Option<String>,
     profile: Option<String>,
     authentication_method: Option<provider::bedrock::BedrockAuthMethod>,
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, SettingsUi)]
+#[settings_ui(group = "Codex CLI")]
+pub struct CodexCliSettingsContent {
+    pub binary_path: Option<String>,
 }
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
@@ -189,6 +202,13 @@ impl settings::Settings for AllLanguageModelSettings {
             merge(
                 &mut settings.bedrock.endpoint,
                 bedrock.as_ref().map(|s| s.endpoint_url.clone()),
+            );
+
+            // Codex CLI
+            let codex_cli = value.codex_cli.clone();
+            merge(
+                &mut settings.codex_cli.binary_path,
+                codex_cli.as_ref().and_then(|s| s.binary_path.clone()),
             );
 
             // Ollama

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -2,7 +2,7 @@ use std::any::TypeId;
 
 use anyhow::Context as _;
 use fs::Fs;
-use gpui::{AnyElement, App, AppContext as _, ReadGlobal as _, Window};
+use gpui::{AnyElement, App, AppContext as _, IntoElement, ParentElement, ReadGlobal as _, Window, div};
 use smallvec::SmallVec;
 
 use crate::SettingsStore;
@@ -174,3 +174,19 @@ numeric_stepper_for_num_type!(u64, U64);
 numeric_stepper_for_num_type!(u32, U32);
 // todo(settings_ui) is there a better ui for f32?
 numeric_stepper_for_num_type!(f32, F32);
+
+impl SettingsUi for String {
+    fn settings_ui_item() -> SettingsUiItem {
+        SettingsUiItem::Single(SettingsUiItemSingle::Custom(Box::new(|settings_value, _window, _cx| {
+            div()
+                .child(format!("Item: {}", settings_value.path.join(".")))
+                .into_any_element()
+        })))
+    }
+}
+
+impl SettingsUi for Option<String> {
+    fn settings_ui_item() -> SettingsUiItem {
+        <String as SettingsUi>::settings_ui_item()
+    }
+}


### PR DESCRIPTION
## Summary
- add settings structs for Codex CLI provider and integrate into language model settings
- provide default Codex CLI configuration
- enable string fields in Settings UI

## Testing
- `cargo test -p language_models` *(fails: trait `Default` not implemented for `gpui::Entity<State>` in codex_cli provider)*

------
https://chatgpt.com/codex/tasks/task_e_68b87cab24d88325a0b5a9a6b2ff2864