### PR TITLE
docs: document Codex CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Welcome to Zed, a high-performance, multiplayer code editor from the creators of [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
+Zed supports AI-powered workflows with local agents like Codex CLI.
+
 ---
 
 ### Installation

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -18,6 +18,7 @@ Here's all the supported LLM providers for which you can use your own API keys:
 
 - [Amazon Bedrock](#amazon-bedrock)
 - [Anthropic](#anthropic)
+- [Codex CLI](#codex-cli)
 - [DeepSeek](#deepseek)
 - [GitHub Copilot Chat](#github-copilot-chat)
 - [Google AI](#google-ai)
@@ -158,6 +159,42 @@ You can configure a model to use [extended thinking](https://docs.anthropic.com/
   }
 }
 ```
+
+### Codex CLI {#codex-cli}
+
+1. Install Codex CLI:
+
+   ```sh
+   npm i -g @openai/codex
+   # or
+   brew install openai/codex/codex
+   ```
+
+2. Authenticate by running:
+
+   ```sh
+   codex auth login
+   ```
+
+   Alternatively, add your API key to `~/.codex/config.toml`:
+
+   ```toml
+   api_key = "your-api-key"
+   ```
+
+3. Add the Codex CLI provider to your Zed `settings.json`:
+
+   ```json
+   {
+     "language_models": {
+       "codex_cli": {
+         "binary_path": "codex"
+       }
+     }
+   }
+   ```
+
+Codex CLI stores its configuration in `~/.codex/config.toml` and will read any `AGENTS.md` file in your project for additional instructions.
 
 ### DeepSeek {#deepseek}
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -4,7 +4,7 @@ Learn how to get started using AI with Zed and all its capabilities.
 
 ## Setting up AI in Zed
 
-- [Configuration](./configuration.md): Learn how to set up different language model providers like Anthropic, OpenAI, Ollama, Google AI, and more.
+- [Configuration](./configuration.md): Learn how to set up different language model providers like Anthropic, OpenAI, Codex CLI, Ollama, Google AI, and more.
 
 - [External Agents](./external-agents.md): Learn how to plug in your favorite agent into Zed.
 


### PR DESCRIPTION
## Summary
- document Codex CLI in LLM providers guide, including installation, auth, settings, and AGENTS.md support
- mention Codex CLI in AI overview and README as a supported local agent

## Testing
- `cargo test -p language_models` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b8921625048325af6a8cff01c334ed