### PR TITLE
Remove default derive from Codex CLI provider

### DIFF
--- a/crates/language_models/src/provider/codex_cli.rs
+++ b/crates/language_models/src/provider/codex_cli.rs
@@ -23,7 +23,7 @@ const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("codex
 const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Codex CLI");
 const CODEX_CLI_SITE: &str = "https://github.com/microsoft/Codex-CLI";
 
-#[derive(Default)]
+
 pub struct CodexCliLanguageModelProvider {
     state: gpui::Entity<State>,
 }


### PR DESCRIPTION
## Summary
- fix Codex CLI provider struct so it no longer derives `Default`

## Testing
- `cargo check` *(fails: build not completed; compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ba859da4832583b087fd6b2518ac