### PR TITLE
Use OpenAI Codex CLI repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Welcome to Zed, a high-performance, multiplayer code editor from the creators of [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
-Zed supports AI-powered workflows with local agents like Codex CLI.
+Zed supports AI-powered workflows with local agents like [Codex CLI](https://github.com/openai/codex).
 
 ---
 

--- a/crates/language_models/src/provider/codex_cli.rs
+++ b/crates/language_models/src/provider/codex_cli.rs
@@ -23,7 +23,7 @@ use util::{ResultExt, command::new_smol_command, paths};
 
 const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("codex-cli");
 const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Codex CLI");
-const CODEX_CLI_SITE: &str = "https://github.com/microsoft/Codex-CLI";
+const CODEX_CLI_SITE: &str = "https://github.com/openai/codex";
 
 pub struct CodexCliLanguageModelProvider {
     state: gpui::Entity<State>,

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -167,8 +167,10 @@ You can configure a model to use [extended thinking](https://docs.anthropic.com/
    ```sh
    npm i -g @openai/codex
    # or
-   brew install openai/codex/codex
+   brew install codex
    ```
+
+   See the [Codex CLI repository](https://github.com/openai/codex) for additional installation options.
 
 2. Authenticate by running:
 


### PR DESCRIPTION
## Summary
- point Codex CLI provider to https://github.com/openai/codex
- update Codex CLI setup docs for new repository and Homebrew formula
- link Codex CLI in README

## Testing
- `cargo test -p language_models` *(fails: linker `clang` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cdf991108325b18a740921fdd6de